### PR TITLE
「乱」命令を実行するとエラーがでるバグを修正

### DIFF
--- a/noukin.py
+++ b/noukin.py
@@ -48,5 +48,5 @@ with open(path) as f:  # open file
                     elif code[pos] == "始":
                         nest -= 1
         elif code[pos] == "乱":
-            code[pos] = random.randint(0, 255)
+            mem[pointer] = random.randint(0, 255)
         pos += 1


### PR DESCRIPTION
# Issue

 #1 

# 内容

 乱命令の乱数の代入先を`code[pos]`から、`mem[pointer]`に修正

# 確認手順

以下のコードを実行
```
乱出
```
